### PR TITLE
Add new approach for identifying nearby particles to reduce collision checks

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,7 +16,9 @@ app.init = function () {
   app.splitTime = Date();
   app.closestPair = {x: 0, y: 0, d: 0};
   app.eventListener = {};
-  app.collissions = 0;
+  app.collisions = 0;
+  app.COLLISION_IMMENENCE_RANGE = 1;
+  app.potentialCollisions = app.resetPotentialCollisions();
   app.thrust = new Thrust();
 
   if(document && document.getElementById) {
@@ -45,6 +47,26 @@ app.init = function () {
   var x = new Particles().buildInitialParticles();
   requestAnimationFrame(app.viewPort.frame);
 };
+
+app.resetPotentialCollisions = function() {
+  app.potentialCollisions = { "0": [], "1": [], "5": [], "10": [], "50": [], "100": [] };
+}
+
+app.flattenPotentialCollisions = function() {
+  var flat = [];
+
+  for (var bucket in app.potentialCollisions) {
+    var list = app.potentialCollisions[(new Number(bucket) / 100)];
+    if (list && list.length)
+      for (var pair in list) {
+        var big = app.particles[list[pair][0]];
+        var little = app.particles[list[pair][1]];
+        flat.push({big: big, little: little});
+      }
+  }
+
+  return flat;
+}
 
 
 var mockCtx = function() {

--- a/app.js
+++ b/app.js
@@ -17,7 +17,7 @@ app.init = function () {
   app.closestPair = {x: 0, y: 0, d: 0};
   app.eventListener = {};
   app.collisions = 0;
-  app.COLLISION_IMMENENCE_RANGE = 1;
+  app.COLLISION_IMMENENCE_RANGE = .1;
   app.potentialCollisions = app.resetPotentialCollisions();
   app.thrust = new Thrust();
 

--- a/particle.js
+++ b/particle.js
@@ -52,7 +52,9 @@ Particle.prototype.calcAccelerationOpen = function(d3Fn){
       dy = curr.y - this.y;
       d3 = d3Fn(dx, dy);
 
-      this.checkPotentialCollision(d3, curr);
+      if (d3 < app.COLLISION_IMMENENCE_RANGE) {
+        this.checkPotentialCollision(d3, curr);
+      }
 
       // if(d3 < app.closestPair.d || app.closestPair === 0) {
       //   app.closestPair.d = Math.sqrt(dx * dx + dy * dy);
@@ -74,7 +76,7 @@ Particle.prototype.checkPotentialCollision = function(d3, curr) {
   // collision detection: if we're in range, add us (this particle and it's acceleration pair)
   // to the global list of potential collisions.  To avoid redundant work, only do this when
   // this particle has the lower id of the pair.  (don't do it twice when we calculate the inverse)
-  if (d3 < app.COLLISION_IMMENENCE_RANGE && this.id < curr.id) {
+  if (this.id < curr.id) {
     var lastBucket = -1;
     for (var bucket in app.potentialCollisions) {
       var num = (new Number(bucket) / 100);

--- a/particle.js
+++ b/particle.js
@@ -52,6 +52,8 @@ Particle.prototype.calcAccelerationOpen = function(d3Fn){
       dy = curr.y - this.y;
       d3 = d3Fn(dx, dy);
 
+      this.checkPotentialCollision(d3, curr);
+
       // if(d3 < app.closestPair.d || app.closestPair === 0) {
       //   app.closestPair.d = Math.sqrt(dx * dx + dy * dy);
       //   app.closestPair.d = app.closestPair.d * app.closestPair.d;
@@ -64,6 +66,22 @@ Particle.prototype.calcAccelerationOpen = function(d3Fn){
         this.accx += grav * dx;
         this.accy += grav * dy;
       }
+    }
+  }
+};
+
+Particle.prototype.checkPotentialCollision = function(d3, curr) {
+  // collision detection: if we're in range, add us (this particle and it's acceleration pair)
+  // to the global list of potential collisions.  To avoid redundant work, only do this when
+  // this particle has the lower id of the pair.  (don't do it twice when we calculate the inverse)
+  if (d3 < app.COLLISION_IMMENENCE_RANGE && this.id < curr.id) {
+    var lastBucket = -1;
+    for (var bucket in app.potentialCollisions) {
+      var num = (new Number(bucket) / 100);
+      if (lastBucket < d3 && d3 < num)
+        app.potentialCollisions[(lastBucket * 100).toString()].push([this.id, curr.id]);
+
+      lastBucket = num;
     }
   }
 };

--- a/physics.js
+++ b/physics.js
@@ -45,11 +45,6 @@ Physics.prototype.leapFrog = function () {
     ps[i].updateVelocity();
   }  
 
-  if(app.physics.variables.CALC_STYLE === 'wacky') {
-    this.glomParticles();
-  }
-
-
   if(app.response.MODE === 'ROCKET') {
     ps[app.FOLLOW].velx += (-app.thrust.getThrustVector().x / 3000);
     ps[app.FOLLOW].vely += (-app.thrust.getThrustVector().y / 3000);
@@ -148,17 +143,15 @@ Physics.prototype.createCollidingParticleList = function() {
   return ret;
 };
 
-Physics.prototype.glomParticles = function() {
-  var set = this.createCollidingParticleList();
-
-  app.collissions += set.length;
+Physics.prototype.glomParticles = function(set) {
+  app.collisions += set.length;
 
   if(set.length > 0) {
     for(var i = 0; i < set.length; i++) {
       this.collide_glom(set[i].big, set[i].little);
     }
     
-    // this is garbage collecter heaven here.... clean up at some point if we want a speed boost from post-collissions.
+    // this is garbage collecter heaven here.... clean up at some point if we want a speed boost from post-collisions.
     var newParticles = [];
     for(i = 0; i < app.particles.length; i++){
       if(app.particles[i].destroyed !== true) {

--- a/physics.js
+++ b/physics.js
@@ -143,6 +143,20 @@ Physics.prototype.createCollidingParticleList = function() {
   return ret;
 };
 
+Physics.prototype.handleCollisions = function() {
+  var coll = app.potentialCollisions["0"]; //app.flattenPotentialCollisions();
+  if(coll.length) {
+    for (var pair in coll) {
+      var a = app.particles[coll[pair][0]];
+      var b = app.particles[coll[pair][1]];
+      if (app.physics.areParticlesVeryClose(a, b)) {
+        var flip = b.mass > a.mass;
+        app.physics.glomParticles([{ big: (flip ? b : a), little: (flip ? a : b)}]);
+      }
+    }
+  }
+};
+
 Physics.prototype.glomParticles = function(set) {
   app.collisions += set.length;
 

--- a/response.js
+++ b/response.js
@@ -251,7 +251,9 @@ Response.prototype.reset = function() {
   app.CLOCK.e = 0;
   app.CLOCK.j = 0;
   app.CLOCK.n = 0;
-  app.collissions = 0;
+  app.collisions = 0;
+
+  app.resetPotentialCollisions();
 }
 
 Response.prototype.pause = function() {

--- a/viewPort.js
+++ b/viewPort.js
@@ -230,7 +230,32 @@ ViewPort.prototype.frameClock = function() {
 
     this.appendLine("Total system mass: " + totalMass);
     this.appendLine("Total system energy: " + totalEnergy);
-    this.appendLine("Total collissions: " + app.collissions);
+    this.appendLine("Total collisions: " + app.collisions);
+    this.appendLine("Potential collisions: ");
+    this.appendLine("----------------------");
+
+    var lastBucket = null;
+    for (var bucket in app.potentialCollisions) {
+      var num = (new Number(bucket) / 100);
+      if (lastBucket) {
+        var list = app.potentialCollisions[lastBucket];
+        if (list.length) {
+          this.appendLine("Items between " + (lastBucket / 100) + " and " + num + " apart: ");
+
+          for (var pair in list) {
+            pair = list[pair];
+            var a = app.particles[pair[0]];
+            var b = app.particles[pair[1]];
+            this.appendLine("    " + a.name + " and " + b.name);
+          }
+        }
+      }
+
+      lastBucket = bucket;
+    }
+    this.appendLine("----------------------");
+
+
 
     // var maxMass = 0;
     // for(var xx = 0; xx < app.particles.length; xx++) {
@@ -262,7 +287,20 @@ ViewPort.prototype.integrateWrapper = function() {
     app.physics.constants.GRAVITY_CONSTANT /= app.physics.variables.TIME_STEP;
   }*/
 
+  app.resetPotentialCollisions();
+
   app.physics.leapFrog();
+
+  var coll = app.potentialCollisions["0"]; //app.flattenPotentialCollisions();
+  if(coll.length)
+    for (var pair in coll) {
+      var a = app.particles[coll[pair][0]];
+      var b = app.particles[coll[pair][1]];
+      if (app.physics.areParticlesVeryClose(a, b)) {
+        var flip = b.mass > a.mass;
+        app.physics.glomParticles([{ big: (flip ? b : a), little: (flip ? a : b)}]);
+      }
+    }
 };
 
 

--- a/viewPort.js
+++ b/viewPort.js
@@ -290,17 +290,7 @@ ViewPort.prototype.integrateWrapper = function() {
   app.resetPotentialCollisions();
 
   app.physics.leapFrog();
-
-  var coll = app.potentialCollisions["0"]; //app.flattenPotentialCollisions();
-  if(coll.length)
-    for (var pair in coll) {
-      var a = app.particles[coll[pair][0]];
-      var b = app.particles[coll[pair][1]];
-      if (app.physics.areParticlesVeryClose(a, b)) {
-        var flip = b.mass > a.mass;
-        app.physics.glomParticles([{ big: (flip ? b : a), little: (flip ? a : b)}]);
-      }
-    }
+  app.physics.handleCollisions();
 };
 
 


### PR DESCRIPTION
Create a new app state objects, potentialCollisions
 	Sort out potential collisions into distance buckets when calculating d3 in physics loop
 	Only pass members of the smallest-distance bucket to the expensive collision detection call