### PR TITLE
Implement {x,y,z} setting and getting methods for Vector3d

### DIFF
--- a/particles.js
+++ b/particles.js
@@ -115,16 +115,18 @@ Particles.prototype.finalize = function() {
     system_momentum = new Vector3d(0., 0., 0.);
     
   for (var i = 0; i < particles.length; i++) {
-      var me = particles[i];
-      system.momentum.x += me.mass * me.vel.x;
-      system.momentum.y += me.mass * me.vel.y;
-      system.momentum.z += me.mass * me.vel.z;
+      var vel = particles[i].vel.asXYZ;
+      system.momentum.x += me.mass * vel.x;
+      system.momentum.y += me.mass * vel.y;
+      system.momentum.z += me.mass * vel.z;
   }
   //Give the Sun a little kick to zero out the system's momentum:
   var sun = app.particles[0];
-  sun.vel.x -= system_momentum.x / sun.mass;
-  sun.vel.y -= system_momentum.y / sun.mass;
-  sun.vel.z -= system_momentum.z / sun.mass;
+  var sunVel  = sun.vel.asXYZ();
+  sunVel.x -= system_momentum.x / sun.mass;
+  sunVel.y -= system_momentum.y / sun.mass;
+  sunVel.z -= system_momentum.z / sun.mass;
+  sun.vel.setXYZ(sunVel.x, sunVel.y, sunVel.z);
 
   //This has to be done once before integration can occur. Prime The Pump!
   for (var i = 0; i < app.particles.length; i++) {

--- a/physics.js
+++ b/physics.js
@@ -58,9 +58,11 @@ Physics.prototype.leapFrog = function () {
   }  
 
   if(app.response.MODE === 'ROCKET') {
-    ps[app.FOLLOW].vel.x -= app.thrust.getThrustVector().x / 3000;
-    ps[app.FOLLOW].vel.y -= app.thrust.getThrustVector().y / 3000;
-    ps[app.FOLLOW].vel.z -= app.thrust.getThrustVector().z / 3000;
+    rocketVel = ps[app.FOLLOW].vel.asXYZ();
+    rocketVel.x -= app.thrust.getThrustVector().x / 3000;
+    rocketVel.y -= app.thrust.getThrustVector().y / 3000;
+    rocketVel.z -= app.thrust.getThrustVector().z / 3000;
+    ps[app.FOLLOW].v.setXYZ(rocketVel.x, rocketVel.y, rocketVel.z);
   }
 };
 

--- a/vector3d.js
+++ b/vector3d.js
@@ -4,14 +4,26 @@ function Vector3d(x, y, z){
 	this.z = z;
 }
 
-Vector3d.prototype.setcoords = function(x, y, z){
+Vector3d.prototype.setXYZ = function(x, y, z){
 	this.x = x;
 	this.y = y;
 	this.z = z;
-}
+};
+
+Vector3d.prototype.setFromV = function(v){
+	this.x = v.x;
+	this.y = v.y;
+	this.z = v.z;
+};
+
+Vector3d.prototype.asXYZ = function(){
+	return { x: this.x,
+			y: this.y,
+			z: this.z}
+};
 
 Vector3d.prototype.zero = function(){
-    this.setcoords(0., 0., 0.);
+    this.setXYZ(0., 0., 0.);
 }
 
 

--- a/viewPort.js
+++ b/viewPort.js
@@ -67,7 +67,7 @@ ViewPort.prototype.drawParticles = function() {
   var particles = app.particles;
 
   var currColor = particles[0].drawColor;
-  app.FOLLOWXY = [app.particles[app.FOLLOW].position.x, app.particles[app.FOLLOW].position.y];
+  app.FOLLOWXY = app.particles[app.FOLLOW].position.asXYZ();
   app.ctx.strokeStyle = currColor;
   for(var i = 0 ; i < app.particles.length; i++ ){
     if(particles[i].drawColor != currColor) {
@@ -82,16 +82,17 @@ ViewPort.prototype.drawParticles = function() {
 ViewPort.prototype.drawParticle = function(particle) {
   var obj,
     drawSize = particle.size;
-
+    position = particle.position.asXYZ();
 
   if(app.DRAWSTATE === 0) {
-    obj = app.viewPort.project(particle.position.x, particle.position.y, particle.position.z);
+
+    obj = app.viewPort.project(position.x, position.y, position.z);
     obj.x = obj.x - app.VIEWSHIFT.x;
     obj.y = obj.y - app.VIEWSHIFT.y;
   } else {
-    obj = {x: particle.position.x, y: particle.position.y};
-    obj.x = (obj.x - app.viewPort.center.x - app.VIEWSHIFT.x) + (obj.x - app.FOLLOWXY[0]) * app.VIEWSHIFT.zoom;
-    obj.y = (obj.y - app.viewPort.center.y - app.VIEWSHIFT.y) + (obj.y - app.FOLLOWXY[1]) * app.VIEWSHIFT.zoom;
+    obj = position;
+    obj.x = (obj.x - app.viewPort.center.x - app.VIEWSHIFT.x) + (obj.x - app.FOLLOWXY.x) * app.VIEWSHIFT.zoom;
+    obj.y = (obj.y - app.viewPort.center.y - app.VIEWSHIFT.y) + (obj.y - app.FOLLOWXY.y) * app.VIEWSHIFT.zoom;
   }
 
   if(particle.radius > 1) {
@@ -285,9 +286,10 @@ ViewPort.prototype.showRocketTelemetry = function() {
     this.appendLine("   targeting: " + app.particles[3].name);
     this.appendLine("     target speed: " + Math.round(app.physics.getParticleSpeed(app.particles[3]) * 1000, 0));
     this.appendLine("     target direction: " + Math.round(app.particles[3].direction, 0));
-
-    var d3Sol = Math.round(focusParticle.dist(focusParticle.x - app.particles[0].x, focusParticle.y - app.particles[0].y, 0) / app.physics.constants.ASTRONOMICAL_UNIT * 500);
-    var d3Target = Math.round(focusParticle.dist(focusParticle.x - app.particles[3].x, focusParticle.y - app.particles[3].y, 0) / app.physics.constants.ASTRONOMICAL_UNIT * 500);
+    var solPosition = app.particles[0].position.asXYZ();
+    var d3Sol = Math.round(focusParticle.dist(focusParticle.x - solPosition.x, focusParticle.y - solPosition, 0) / app.physics.constants.ASTRONOMICAL_UNIT * 500);
+    var earthPosition = app.particles[3].position.asXYZ();
+    var d3Target = Math.round(focusParticle.dist(focusParticle.x - earthPosition.x, focusParticle.y - earthPosition.y, 0) / app.physics.constants.ASTRONOMICAL_UNIT * 500);
     this.appendLine("     d(SOL): " + (d3Sol / 500));
     this.appendLine("     d(TAR): " + (d3Target / 500));
 


### PR DESCRIPTION
Outside of particle.js, references to a particle’s position is done via
setting; like p.position.setXYZ(x, y, z); or getting:
myParticlesPosition = p.position.asXYZ().

Vector3d implements these methods, but the names were chosen from discussion as in issue #30.