### PR TITLE
Consolidate destroyed particle cleanout 

### DIFF
--- a/app.js
+++ b/app.js
@@ -107,7 +107,7 @@ app.freeTheDestroyed = function() {
     if (app.FOLLOW == j) app.FOLLOW = newId;
     if (app.particles[j] && app.particles[j].destroyed==false){
       survivors.push(app.particles[j]);
-      newId ++;
+      app.particles[j].id = newId ++;
     }
   }
 

--- a/app.js
+++ b/app.js
@@ -99,6 +99,22 @@ app.clockReset = function() {
   app.splitTime = new Date();
 };
 
+app.freeTheDestroyed = function() {
+  var survivors = [];
+  var newId = 0;
+
+  for(var j=0; j < app.particles.length; j++){
+    if (app.FOLLOW == j) app.FOLLOW = newId;
+    if (app.particles[j] && app.particles[j].destroyed==false){
+      survivors.push(app.particles[j]);
+      newId ++;
+    }
+  }
+
+  if(app.FOLLOW >= survivors.length) app.FOLLOW = 0;
+
+  app.particles = survivors;
+};
 
 var mockCtx = function() {
 

--- a/app.js
+++ b/app.js
@@ -99,23 +99,6 @@ app.clockReset = function() {
   app.splitTime = new Date();
 };
 
-app.freeTheDestroyed = function() {
-  var survivors = [];
-  var newId = 0;
-
-  for(var j=0; j < app.particles.length; j++){
-    if (app.FOLLOW == j) app.FOLLOW = newId;
-    if (app.particles[j] && app.particles[j].destroyed==false){
-      survivors.push(app.particles[j]);
-      app.particles[j].id = newId ++;
-    }
-  }
-
-  if(app.FOLLOW >= survivors.length) app.FOLLOW = 0;
-
-  app.particles = survivors;
-};
-
 var mockCtx = function() {
 
   this.fillText = function() {

--- a/particle.js
+++ b/particle.js
@@ -8,13 +8,19 @@ function Particle(id, x, y, z) {
   this.r = new Vector3d(0., 0., 0.); //Vector pointing from self to another.
   this.dt = app.physics.variables.TIME_STEP_INTEGRATOR;
   this.dt_old = this.dt;
-  this.remove = false;
+  this.destroyed = false;
 
   this.mass = 2;
   this.color = {r: 205 + 50 * Math.floor(Math.random() * 3), 
     g:  205 + 50 * Math.floor(Math.random() * 3),
     b:  205 + 50 * Math.floor(Math.random() * 3)};
 };
+
+Particle.prototype.die = function(message){
+  this.destroyed = true;
+  console.log(message);
+}
+
 
 Particle.prototype.speed_squared = function(){
   return this.vel.sumsq() / (this.dt*this.dt);

--- a/particles.js
+++ b/particles.js
@@ -141,3 +141,20 @@ Particles.prototype.buildParticle = function(cfg) {
     tmp.configure(cfg);
     app.particles.push(tmp);
 };
+
+Particles.prototype.freeTheDestroyed = function() {
+  var survivors = [];
+  var newId = 0;
+
+  for(var j=0; j < app.particles.length; j++){
+    if (app.FOLLOW == j) app.FOLLOW = newId;
+    if (app.particles[j] && app.particles[j].destroyed==false){
+      survivors.push(app.particles[j]);
+      app.particles[j].id = newId ++;
+    }
+  }
+
+  if(app.FOLLOW >= survivors.length) app.FOLLOW = 0;
+
+  app.particles = survivors;
+};

--- a/physics.js
+++ b/physics.js
@@ -92,18 +92,10 @@ Physics.prototype.collide_glom = function(p1, p2) {
   little.position.scale(fracL);
   big.position.increment(little.position);
   
-  // big.oldpos.scale(fracB);
-  // little.oldpos.scale(fracL);
-  // big.oldpos.v_inc_by(little.oldpos);
-
   big.vel.scale(fracB);
   little.vel.scale(fracL);
   big.vel.increment(little.vel);
 
-  // big.oldvel.v_scale(fracB);
-  // little.oldvel.v_scale(fracL);
-  // big.oldvel.v_inc_by(little.oldvel);
-  
   big.acc.scale(fracB);
   little.acc.scale(fracL);
   big.acc.increment(little.acc);
@@ -112,25 +104,7 @@ Physics.prototype.collide_glom = function(p1, p2) {
   little.acc_old.scale(fracL);
   big.acc_old.increment(little.acc_old);
 
-
-  // cfg.U = 0;
-  // cfg.U += big.U || 0;
-  // cfg.U += little.U || 0;
-  // cfg.U += big.kineticE() + little.kineticE() - cfg.kenetic;  //Leftover energy becomes thermal E of new thingy.
-
-  // cfg.kenetic = (1/2) * cfg.mass * (cfg.velx * cfg.velx + cfg.vely * cfg.vely)
-
-
-// Why do we do this to the little particle?  -- bad bad hacky reasons.  better to Oblitterate it.
-  little.mass = 0.00000000000001;
-  little.vel = new Vector3d(0., 0., 0.);
-  little.acc = new Vector3d(0., 0., 0.);
-
-  little.position = Vector3d.prototype.randomOfMagnitude(5000 + 5000 * Math.random());
-  little.color = {r: 0, b: 0, g: 0};
-  little.destroyed = true;
-
-
+  little.die(little.name + " was swallowed by " + big.name + ".");
   if(app.FOLLOW === little.id) {
     app.FOLLOW = big.id;
   }
@@ -187,23 +161,6 @@ Physics.prototype.glomParticles = function(set) {
     for(var i = 0; i < set.length; i++) {
       this.collide_glom(set[i].big, set[i].little);
     }
-    
-    // this is garbage collecter heaven here.... clean up at some point if we want a speed boost from post-collisions.
-    var newParticles = [];
-    for(i = 0; i < app.particles.length; i++){
-      if(app.particles[i].destroyed !== true) {
-        newParticles.push(app.particles[i]);
-      }
-    }
-
-    for(i = 0; i < newParticles.length; i++){
-      if(app.FOLLOW === newParticles[i].id) {
-        app.FOLLOW = i;
-      }
-      newParticles[i].id = i;
-    }
-
-    app.particles = newParticles;
   }
 };
 

--- a/response.js
+++ b/response.js
@@ -198,18 +198,9 @@ Response.prototype.getNearest = function(clickXY){
 }
 
 Response.prototype.destroy = function(xy){
-  var currIndex = Response.prototype.getNearest(xy);
-
-  var tmp = [];
-  for(var j = 0; j < app.particles.length; j++) {
-    if(j != currIndex) {
-      tmp.push(app.particles[j]);
-    }
-  }
-
-  app.particles = tmp;
-
-  if(app.FOLLOW == currIndex) app.FOLLOW = 0;
+  var target = app.particles[Response.prototype.getNearest(xy)];
+  target.die(target.name + " was destroyed by the creator.")
+  if(app.FOLLOW == target.id) app.FOLLOW = 0;
 };
 
 Response.prototype.rocket = function(){
@@ -285,12 +276,15 @@ Response.prototype.changeView = function() {
 }
 
 Response.prototype.incrementFollow = function () {
-  app.FOLLOW += 1;
+  var oldFollow = app.FOLLOW;
+  do{
+    app.FOLLOW += 1;
+    if(app.FOLLOW >= app.particles.length) app.FOLLOW = 0;
+  }while(app.particles[app.FOLLOW].destroyed && app.FOLLOW != oldFollow);
+
   app.viewPort.shift.x = 0;
-  app.viewPort.shift.y= 0;
-  if(app.FOLLOW >= app.particles.length) {
-    app.FOLLOW = 0;
-  }
+  app.viewPort.shift.y = 0;
+  
 }
 
 Response.prototype.changeProperty = function(id, propName, newValue) {

--- a/viewPort.js
+++ b/viewPort.js
@@ -311,6 +311,9 @@ ViewPort.prototype.integrateWrapper = function() {
 
   app.physics.leapFrog();
   app.physics.handleCollisions();
+
+  app.freeTheDestroyed();
+
 };
 
 

--- a/viewPort.js
+++ b/viewPort.js
@@ -312,7 +312,7 @@ ViewPort.prototype.integrateWrapper = function() {
   app.physics.leapFrog();
   app.physics.handleCollisions();
 
-  app.freeTheDestroyed();
+  Particles.prototype.freeTheDestroyed();
 
 };
 


### PR DESCRIPTION
Particles have property "destroyed" set to false from birth.  Destroying
via Particle.die(message) sets destroyed flag, and announces its death.

Response.incrementFollow will iterate through particles until it finds
a non-destroyed one.  Gives up if it returns to original particle.

Surviving particles are given new Id’s consistent with app.particles
index.
Fixes both #25 and #39.